### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ RUN buildDeps='git alpine-sdk openssl-dev libwebsockets-dev c-ares-dev util-linu
     sed -i "s/BACKEND_HTTP ?= no/BACKEND_HTTP ?= yes/" config.mk && \
     sed -i "s/BACKEND_MYSQL ?= yes/BACKEND_MYSQL ?= no/" config.mk && \
     sed -i "s/MOSQUITTO_SRC =/MOSQUITTO_SRC = ..\//" config.mk && \
+    sed -i "s/EVP_MD_CTX_new/EVP_MD_CTX_create/g" cache.c && \
+    sed -i "s/EVP_MD_CTX_free/EVP_MD_CTX_destroy/g" cache.c && \
     make && \
     cp auth-plug.so /usr/local/lib/ && \
     cp np /usr/local/bin/ && chmod +x /usr/local/bin/np && \


### PR DESCRIPTION
Due to the version of openssl in alpine3.4 is 1.0.2j, the function names in mosquitto-auth-plug should fall back to their previous names for now, until alpine3.4 update its openssl version or alpine3.5 will take over with latest version.