### PR TITLE
Pinned to alpine:3.8 to avoid dep conflict

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.8
 
 EXPOSE 1883
 EXPOSE 9883

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -1,7 +1,5 @@
 # Config file for mosquitto
-retry_interval 20
 sys_interval 10
-store_clean_interval 10
 user mosquitto
 max_inflight_messages 40
 max_queued_messages 200


### PR DESCRIPTION
Suggestion to pin the Alpine image version, in line with best practices and allowing closure of https://github.com/jllopis/docker-mosquitto/issues/13. Thanks!